### PR TITLE
Added a check before split().

### DIFF
--- a/avalon.getModel.js
+++ b/avalon.getModel.js
@@ -21,6 +21,9 @@ define(["avalon"], function(avalon) {
    // 比如 vm.aaa.bbb = {} ; 
    // avalon.getModel("aaa.bbb", vmodels) ==> ["bbb", bbbVM, bbbVM所在的祖先VM（它位于vmodels中）]
     avalon.getModel = function(expr, vmodels){
+        if (!expr) {
+            return null;
+        }
         var str = expr.split('.'),
             strLen = str.length,
             last = str[strLen-1];


### PR DESCRIPTION
In order to prevent the code from crashing if `expr` is `undefined` or `""`.
