### PR TITLE
textbox自动补全功能增加字母过滤选项

### DIFF
--- a/textbox/avalon.textbox.doc.html
+++ b/textbox/avalon.textbox.doc.html
@@ -44,6 +44,12 @@
                         <td>配置输入框有自动提示补全功能，提示类型由用户自定义，默认配置为false，也就是不开启自动补全功能</td>
                     </tr>
                     <tr>
+                        <td>suggestDisableLetter</td>
+                        <td>Boolean</td>
+                        <td>false</td>
+                        <td>配置输入框进行自动提示补全时，是否对字母进行过滤，默认配置为false,也就是说输入值包含字母时也会进行自动补全</td>
+                    </tr>
+                    <tr>
                         <td>autoTrim</td>
                         <td>Boolean</td>
                         <td>true</td>

--- a/textbox/avalon.textbox.js
+++ b/textbox/avalon.textbox.js
@@ -37,7 +37,8 @@ define(["./avalon.suggest", "text!./avalon.textbox.html","css!../chameleon/oniui
                     focus : options.suggestFocus || false ,
                     onChange : options.suggestOnChange || "",
                     type: "textbox",
-                    limit: options.limit || 8
+                    limit: options.limit || 8,
+                    disableLetter:options.suggestDisableLetter || false
                 }
             $suggestopts = avalon.mix(suggestConfig, options.suggestion)
             options.$suggestopts = $suggestopts;


### PR DESCRIPTION
在textbox的options中添加suggestDisableLetter选项（默认值为false）。suggestDisableLetter=true时，在自动补全功能中，如果输入为拼音时不触发自动补全的下拉框更新。针对搜狗输入法在输入中文时，会先在输入框中输入为拼音，如果采用ajax请求获取下拉框内容，会造成请求次数过多。