### PR TITLE
dropdown: 修复设置select的multiple="false"使其依然为多选

### DIFF
--- a/dropdown/avalon.dropdown.js
+++ b/dropdown/avalon.dropdown.js
@@ -143,9 +143,10 @@ define(["avalon",
                 //如果原来的select没有子节点，那么为它添加option与optgroup
                 if (!hasBuiltinTemplate) {
                     element.appendChild(getFragmentFromData(dataModel));
-                    avalon.each(["multiple", "size"], function(i, attr) {
-                        avalon(element).attr(attr, vmodel[attr]);
-                    });
+                    avalon(element).attr("size", vmodel["size"]);
+                    if(vmodel["multiple"]){
+                        avalon(element).attr("multiple", vmodel["multiple"]);
+                    }
                 }
 
                 if (!vmodel.multiple) {


### PR DESCRIPTION
dropdown: 修复设置select的multiple="false"使其依然为多选