### PR TITLE
修复dropdown和resize bug

### DIFF
--- a/dropdown/avalon.dropdown.ex2.html
+++ b/dropdown/avalon.dropdown.ex2.html
@@ -10,7 +10,7 @@
             require(["dropdown/avalon.dropdown.js", "ready!"], function() {
                 //multiple select vmodel
                 avalon.define('mulSelect', function(vm) {
-                    vm.s1 = ['value1', 1, null, false];
+                    vm.s1 = ['value1', '1', null, false];
                 });
                 avalon.scan();
             });

--- a/dropdown/avalon.dropdown.js
+++ b/dropdown/avalon.dropdown.js
@@ -809,7 +809,7 @@ define(["avalon",
             data = data === "true" ? true :
                 data === "false" ? false :
                     data === "null" ? null :
-                        +data + "" === data ? +data : data;
+                        data + "" === data ? data : +data;
         } catch (e) {
         }
         return data

--- a/dropdown/avalon.dropdown.js
+++ b/dropdown/avalon.dropdown.js
@@ -901,7 +901,7 @@ define(["avalon",
                 if (el.tagName === "OPTGROUP") {
                     parent = {
                         label: el.label,
-                        value: "",
+                        value: "__dropdownGroup",
                         enable: !el.disabled,
                         group: true,        //group不能添加ui-state-active
                         parent: false,
@@ -913,7 +913,7 @@ define(["avalon",
                     ret.push({
                         label: el.label.trim()||el.text.trim()||el.value.trim(), //IE9-10有BUG，没有进行trim操作
                         title: el.title.trim(),
-                        value: parseData(el.value.trim()||el.text.trim()),
+                        value: parseData(el.value.trim()),
                         enable: ensureBool(parent && parent.enable, true) && !el.disabled,
                         group: false,
                         parent: parent,

--- a/resizable/avalon.resizable.js
+++ b/resizable/avalon.resizable.js
@@ -65,9 +65,7 @@ define(["../draggable/avalon.draggable"], function(avalon) {
         //data.originalX = offset.left; data.originalY = offset.top;
         options.beforeStart = function(event, data) {
             var target = data.$element;
-            if(_drag === avalon.noop){
                 data.dragX = data.dragY = false
-            }
             var dir = getDirection(event, target, data);
             if (dir === "")
                 return;


### PR DESCRIPTION
修复同时有draggable和resizable时，resize导致元素跳动
dropdown: 修复当value为字符串格式的数字时，会转化为纯数字
dropdown: 允许value为空字符串的情况